### PR TITLE
Added meta viewport tag, for mobile friendliness

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ body {
   font-family: 'OFL Sorts Mill Goudy TT';
 }
 </style>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <span id='weekday'></span> at Compline<br/>


### PR DESCRIPTION
I added the viewport tag to the header, to allow the scores and text to display the correct size on a tablet or phone.

```HTML
<meta name="viewport" content="width=device-width, initial-scale=1.0">
```